### PR TITLE
Fix notification_level null handling for GitLab group owners

### DIFF
--- a/schemas.ts
+++ b/schemas.ts
@@ -296,14 +296,14 @@ export const GitLabRepositorySchema = z.object({
       project_access: z
         .object({
           access_level: z.number(),
-          notification_level: z.number().optional(),
+          notification_level: z.number().nullable().optional(),
         })
         .optional()
         .nullable(),
       group_access: z
         .object({
           access_level: z.number(),
-          notification_level: z.number().optional(),
+          notification_level: z.number().nullable().optional(),
         })
         .optional()
         .nullable(),


### PR DESCRIPTION
## Summary
- Updates Zod schema to accept `null` values for `notification_level` in GitLab API responses
- Fixes TypeError when parsing repository permissions for group owners
- GitLab API returns `null` for `notification_level` when users are group owners instead of numeric values

## Changes
- Modified `schemas.ts` to use `.nullable()` for `notification_level` fields in both `project_access` and `group_access` permission objects
- Ensures compatibility with GitLab's API behavior for different user roles

## Test plan
- [x] Updated type definitions compile successfully
- [x] No breaking changes to existing functionality
- [ ] Test with actual GitLab group owner API responses

🤖 Generated with [Claude Code](https://claude.ai/code)